### PR TITLE
Pinned Crossbeam's version in an attempt to address #8

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13,6 +13,7 @@ name = "cargo-test-junit"
 version = "0.6.7"
 dependencies = [
  "clap 2.19.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "crossbeam 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "duct 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "nom 3.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "sxd-document 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -37,6 +38,11 @@ dependencies = [
 [[package]]
 name = "crossbeam"
 version = "0.2.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "crossbeam"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -150,6 +156,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum bitflags 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "aad18937a628ec6abcd26d1489012cc0e18c21798210f491af69ded9b881106d"
 "checksum clap 2.19.2 (registry+https://github.com/rust-lang/crates.io-index)" = "305ad043f009db535a110200541d4567b63e172b1fe030313fbb92565da7ed24"
 "checksum crossbeam 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)" = "0c5ea215664ca264da8a9d9c3be80d2eaf30923c259d03e870388eb927508f97"
+"checksum crossbeam 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "24ce9782d4d5c53674646a6a4c1863a21a8fc0cb649b3c94dfc16e45071dea19"
 "checksum duct 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "007e0b7f60e219a5c01ad7c7b7ec7b66a6e0f7b0b27f0cfd7789d8077489b1b0"
 "checksum kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
 "checksum libc 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)" = "a51822fc847e7a8101514d1d44e354ba2ffa7d4c194dcab48870740e327cac70"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ repository = "https://github.com/rustation/cargo-test-junit"
 description = "Converts cargo test output into a junit report"
 
 [dependencies]
+crossbeam = "0.3.2"
 test-to-vec = "0.4.3"
 nom = "3.2.1"
 duct = "0.4.0"


### PR DESCRIPTION
# Purpose

There appears to be a breaking API change in `crossbeams` which `duct` depends on.
Building locally works correct, however, `cargo install cargo-test-junit` fails as indicated in #8.
This PR attempts to address this build issue.

# What appears to be the cause of the failure

When building locally, `Cargo.lock` - which pins an older version of `crossbeams` - is respected.
However, according to [0], when uploading the package to crates.io, no `Cargo.lock` is uploaded.

I've confirmed that checking out `cargo-test-junit` locally and running `cargo build` works correctly.
However, updating `Cargo.lock` first (ie, `cargo update; cargo build`) results in the same build error as when installing.

Upgrading `duct` results in different build failures due to changes in the `duct` API. Pending someone taking the effort to upgrade `cargo-test-junit` to use the newer version of `duct`, it seems reasonable to pin the version of `crossbeam` in `cart-test-junit`'s `Cargo.toml` file.

That being said, I do not know how to test this more thoroughly than pushing an updated package to `crates.io`.

[0] - https://users.rust-lang.org/t/cargo-install-and-lock-file/4203